### PR TITLE
remove arch because os.arch is not runtime os arch

### DIFF
--- a/.github/workflows/nigthly.yml
+++ b/.github/workflows/nigthly.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Check outputs
         run: |
           OUTPUTS=(
-            "Arch: ${{ steps.system-info.outputs.arch }}"
             "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
             "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
             "Hostname: ${{ steps.system-info.outputs.hostname }}"
@@ -52,7 +51,6 @@ jobs:
       - name: Check outputs
         run: |
           $OUTPUTS = @(
-            "Arch: ${{ steps.system-info.outputs.arch }}",
             "CPU Core: ${{ steps.system-info.outputs.cpu-core }}",
             "CPU Model: ${{ steps.system-info.outputs.cpu-model }}",
             "Hostname: ${{ steps.system-info.outputs.hostname }}",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This action provides GitHub Actions runner OS information.
 
 Name|Description
 ---|---
-`arch`|The operating system CPU architecture
 `cpu-core`|Logical CPU core size
 `cpu-model`|Logical CPU model name
 `hostname`|The host name of the operating system

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,6 @@ branding:
   color: 'gray-dark'
 
 outputs:
-  arch:
-    description: "The operating system CPU architecture"
   cpu-core:
     description: "Logical CPU core size"
   cpu-model:

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ export async function main(): Promise<void> {
 
   core.debug(`System Info: ${JSON.stringify(systemInfo, null, 2)}`);
 
-  core.setOutput("arch", systemInfo.arch);
   core.setOutput("cpu-core", systemInfo.cpu.core);
   core.setOutput("cpu-model", systemInfo.cpu.model);
   core.setOutput("hostname", systemInfo.hostname);

--- a/src/systemInfo.ts
+++ b/src/systemInfo.ts
@@ -5,23 +5,7 @@ import windowsRelase from "windows-release";
 
 import { getosAsync } from "./getosAsync";
 
-export const Arch = {
-  arm: "arm",
-  arm64: "arm64",
-  ia32: "ia32",
-  mips: "mips",
-  mipsel: "mipsel",
-  ppc: "ppc",
-  ppc64: "ppc64",
-  s390: "s390",
-  s390x: "s390x",
-  x32: "x32",
-  x64: "x64",
-} as const;
-type Arch = typeof Arch[keyof typeof Arch];
-
 export type SystemInfo = {
-  arch: typeof Arch[keyof typeof Arch];
   hostname: string;
   cpu: {
     core: number;
@@ -55,7 +39,6 @@ export const getSystemInfo = async (): Promise<SystemInfo> => {
   })();
 
   return Promise.resolve({
-    arch: os.arch() as Arch,
     hostname: os.hostname(),
     cpu: {
       core: cpus.length,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,6 @@
 const mockSetOutput = jest.fn();
 
 import { main } from "../src";
-import { Arch } from "./../src/systemInfo";
 import { nonEmptyStringExpect } from "./helpers/helper";
 
 jest.mock("@actions/core", () => {
@@ -24,16 +23,6 @@ describe("main", () => {
   it("should set correct outputs", async () => {
     await main();
 
-    expect(mockSetOutput).toBeCalledWith(
-      "arch",
-      expect.stringMatching(
-        new RegExp(
-          `^${Object.values(Arch)
-            .map((v) => `(${v})`)
-            .join("|")}$`
-        )
-      )
-    );
     expect(mockSetOutput).toBeCalledWith("cpu-core", expect.any(Number));
     expect(mockSetOutput).toBeCalledWith("cpu-model", nonEmptyStringExpect);
     expect(mockSetOutput).toBeCalledWith("hostname", nonEmptyStringExpect);

--- a/test/systemInfo.test.ts
+++ b/test/systemInfo.test.ts
@@ -1,16 +1,9 @@
-import { Arch, getSystemInfo } from "./../src/systemInfo";
+import { getSystemInfo } from "./../src/systemInfo";
 import { nonEmptyStringExpect, platformList } from "./helpers/helper";
 
 describe("getSystemInfo", () => {
   it("should return system info", async () => {
     await expect(getSystemInfo()).resolves.toMatchObject({
-      arch: expect.stringMatching(
-        new RegExp(
-          `^${Object.values(Arch)
-            .map((v) => `(${v})`)
-            .join("|")}$`
-        )
-      ),
       hostname: nonEmptyStringExpect,
       cpu: {
         core: expect.any(Number),


### PR DESCRIPTION
The `os.arch()` function returns the architecture under which Node.js binary was built.
So I remove arch on outputs.