### PR TITLE
Use Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ outputs:
     description: "the total amount of system memory in bytes"
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "lib/index.js"


### PR DESCRIPTION
This changes the action to use Node 16 to avoid the warning that gets emitted currently:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, kenchan0130/actions-system-info@v1.1.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.