### PR TITLE
Support kernel version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,9 @@ jobs:
           npm run package
       - name: Run action
         uses: ./
+        id: system-info
+      - name: Show action outputs
+        run: |
+          npm run showenv:SYSTEM_INFO_OUTPUTS
+        env:
+          SYSTEM_INFO_OUTPUTS: ${{join(steps.system-info.outputs.*, ', ')}}

--- a/.github/workflows/nigthly.yml
+++ b/.github/workflows/nigthly.yml
@@ -20,6 +20,7 @@ jobs:
             "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
             "Hostname: ${{ steps.system-info.outputs.hostname }}"
             "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
             "Name: ${{ steps.system-info.outputs.name }}"
             "Platform: ${{ steps.system-info.outputs.platform }}"
             "Release: ${{ steps.system-info.outputs.release }}"
@@ -51,6 +52,7 @@ jobs:
             "CPU Model: ${{ steps.system-info.outputs.cpu-model }}",
             "Hostname: ${{ steps.system-info.outputs.hostname }}",
             "Kernel release: ${{ steps.system-info.outputs.kernel-release }}",
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}",
             "Name: ${{ steps.system-info.outputs.name }}",
             "Platform: ${{ steps.system-info.outputs.platform }}",
             "Release: ${{ steps.system-info.outputs.release }}",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Name|Description
 `cpu-model`|Logical CPU model name
 `hostname`|The host name of the operating system
 `kernel-release`|The kernel release
+`kernel-version`|The kernel version
 `name`|The operating system (distribution) name
 `platform`|The operating system identity
 `release`|The operating system (distribution) release

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint --ext .ts,.js --max-warnings=0 src/**/*",
     "lint:fix": "eslint --ext .ts,.js --fix src/**/*",
     "package": "npm run clean && npm run build && ncc build -o lib/ --license LICENSE -m -s",
-    "test": "vitest"
+    "test": "vitest",
+    "showenv:SYSTEM_INFO_OUTPUTS": "node -e 'console.log(process.env.SYSTEM_INFO_OUTPUTS);'"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export async function main(): Promise<void> {
   core.setOutput("hostname", systemInfo.hostname);
   core.setOutput("platform", systemInfo.platform);
   core.setOutput("kernel-release", systemInfo.kernel.release);
+  core.setOutput("kernel-version", systemInfo.kernel.version);
   core.setOutput("name", systemInfo.name);
   core.setOutput("release", systemInfo.release);
   core.setOutput("totalmem", systemInfo.totalmem);

--- a/src/systemInfo.ts
+++ b/src/systemInfo.ts
@@ -14,8 +14,7 @@ export type SystemInfo = {
   totalmem: number; // Bytes
   kernel: {
     release: string;
-    // os.version() is not supported node12 of GitHub Actions yet
-    // version: string;
+    version: string;
   };
   name: string;
   platform: string;
@@ -46,6 +45,7 @@ export const getSystemInfo = async (): Promise<SystemInfo> => {
     },
     kernel: {
       release: os.release(),
+      version: os.version(),
     },
     totalmem: os.totalmem(),
     platform: os.platform(),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -32,6 +32,10 @@ describe("main", () => {
       "kernel-release",
       nonEmptyStringExpect
     );
+    expect(mockSetOutput).toBeCalledWith(
+      "kernel-version",
+      nonEmptyStringExpect
+    );
     expect(mockSetOutput).toBeCalledWith("name", nonEmptyStringExpect);
     expect(mockSetOutput).toBeCalledWith("release", nonEmptyStringExpect);
     expect(mockSetOutput).toBeCalledWith("totalmem", expect.any(Number));

--- a/test/systemInfo.test.ts
+++ b/test/systemInfo.test.ts
@@ -13,6 +13,7 @@ describe("getSystemInfo", () => {
       },
       kernel: {
         release: nonEmptyStringExpect,
+        version: nonEmptyStringExpect,
       },
       platform: expect.stringMatching(
         new RegExp(`^${platformList.map((v) => `(${v})`).join("|")}$`)


### PR DESCRIPTION
Node.js in this package has been versioned up to 16, so the version function in the os package can now be used.
Therefore, I have tried to support the version.