### PR TITLE
chore: bump to node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ If you want to see the specific output contents for each OS, you can check them 
 
 ```yaml
 steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v4
   - uses: kenchan0130/actions-system-info@master
     id: system-info
-  - uses: actions/cache@v2
+  - uses: actions/cache@v4
     with:
       path: ~/.npm
       key: ${{ runner.os }}-${{ steps.system-info.outputs.release }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ outputs:
     description: "the total amount of system memory in bytes"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "lib/index.js"


### PR DESCRIPTION
<img width="1615" alt="image" src="https://github.com/kenchan0130/actions-system-info/assets/5374887/114f4575-d047-4e34-9929-b842205a68a7">

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/